### PR TITLE
Changed case of 'odata-version' key to match the existing key in the …

### DIFF
--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -2198,7 +2198,7 @@ def Assertion_6_4_2_3(self, log) :
     relative_uris = self.relative_uris
 
     rq_headers = self.request_headers()
-    header = 'odata-version'
+    header = 'OData-Version'
 
     for relative_uri in relative_uris:
         #supported version


### PR DESCRIPTION
…dictionary

Previously this was using all lower case for the odata version header, which resulted in two keys differing only by case. httplib ignores case when adding headers to a request so this resulted them getting concatenated and the request header having "4.0, 4.0" or "4.0, 3.0" instead of just a straight version