### PR TITLE
Allowing root URI to have a status of 200 (OK)

### DIFF
--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -1303,16 +1303,25 @@ def Assertion_6_4_18(self, log) :
                 authorization = 'off'
                 rq_headers = self.request_headers()
                 json_payload, headers, status = self.http_HEAD(relative_uris[relative_uri], rq_headers, authorization)
-                if (status == rf_utility.HTTP_OK) :
-                    assertion_status = log.FAIL
-                    log.assertion_log('line', "~ HEAD on %s without authorization returned status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)))
+                if ("Root Service" in relative_uri):
+                    # Root service URI needs to be handled differently as it is allowed to be
+                    # retrieved without auth, so anything other than OK is a failure
+                    if status == rf_utility.HTTP_NOT_FOUND:
+                        log.assertion_log('TX_COMMENT',"WARN: GET %s failed : HTTP status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)) )
+                    else if status != rf_utility.HTTP_OK:
+                        assertion_status = log.FAIL
+                        log.assertion_log('line', "~ HEAD on %s without authorization returned status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)))
+                else:
+                    if (status == rf_utility.HTTP_OK) :
+                        assertion_status = log.FAIL
+                        log.assertion_log('line', "~ HEAD on %s without authorization returned status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)))
 
-                elif (status != rf_utility.HTTP_UNAUTHORIZED):
-                    assertion_status = log.WARN
-                    log.assertion_log('line', "~ HEAD on %s expected HTTP UNAUTHORIZED; returned status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)) )
+                    elif (status != rf_utility.HTTP_UNAUTHORIZED):
+                        assertion_status = log.WARN
+                        log.assertion_log('line', "~ HEAD on %s expected HTTP UNAUTHORIZED; returned status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)) )
 
-                elif status == rf_utility.HTTP_NOT_FOUND:
-                    log.assertion_log('TX_COMMENT',"WARN: GET %s failed : HTTP status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)) )
+                    elif status == rf_utility.HTTP_NOT_FOUND:
+                        log.assertion_log('TX_COMMENT',"WARN: GET %s failed : HTTP status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)) )
                          
     log.assertion_log(assertion_status, None)
     return (assertion_status)

--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -1303,12 +1303,12 @@ def Assertion_6_4_18(self, log) :
                 authorization = 'off'
                 rq_headers = self.request_headers()
                 json_payload, headers, status = self.http_HEAD(relative_uris[relative_uri], rq_headers, authorization)
-                if ("Root Service" in relative_uri):
+                if "Root Service" == relative_uri:
                     # Root service URI needs to be handled differently as it is allowed to be
                     # retrieved without auth, so anything other than OK is a failure
                     if status == rf_utility.HTTP_NOT_FOUND:
                         log.assertion_log('TX_COMMENT',"WARN: GET %s failed : HTTP status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)) )
-                    else if status != rf_utility.HTTP_OK:
+                    elif status != rf_utility.HTTP_OK:
                         assertion_status = log.FAIL
                         log.assertion_log('line', "~ HEAD on %s without authorization returned status %s:%s" % (relative_uris[relative_uri], status, rf_utility.HTTP_status_string(status)))
                 else:


### PR DESCRIPTION
Assertion checks all resources return 401, but root resource is allowed to be accessed without authorisation, so allow that to be an acceptable response