### PR TITLE
Corrected use of accept header that was being overwritten to xml and …

### DIFF
--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -4399,6 +4399,7 @@ def Assertion_6_5_8(self, log) :
     list1 = []
 
     for relative_uri in relative_uris:
+        rq_headers['Accept'] = rf_utility.accept_type['json']
         json_payload, headers, status = self.http_GET(relative_uris[relative_uri], rq_headers, authorization)
         assertion_status_ = self.response_status_check(relative_uris[relative_uri], status, log)      
         # manage assertion status
@@ -4415,8 +4416,7 @@ def Assertion_6_5_8(self, log) :
                 resource = json_payload['@odata.context']
                 #r = requests.get(resource)
                 #print('The response is %s' %r)
-                rq_headers['Content-Type'] = rf_utility.content_type['xml']
-                rq_headers['Accept'] = rf_utility.accept_type['json_xml']
+                rq_headers['Accept'] = rf_utility.accept_type['xml']
                 response,headers,status = self.http_GET(resource,rq_headers,None)
                 if isinstance(response, dict):
                     # received JSON, skip
@@ -4480,6 +4480,7 @@ def Assertion_6_5_9(self, log) :
 
 
     for relative_uri in relative_uris:
+        rq_headers['Accept'] = rf_utility.accept_type['json']
         json_payload, headers, status = self.http_GET(relative_uris[relative_uri], rq_headers, authorization)
         assertion_status_ = self.response_status_check(relative_uris[relative_uri], status, log)      
         # manage assertion status
@@ -4497,8 +4498,7 @@ def Assertion_6_5_9(self, log) :
                 if 'ServiceRoot' in resource :
                         #r = requests.get(resource)
                         #print('The response is %s' %r)
-                        rq_headers['Content-Type'] = rf_utility.content_type['xml']
-                        rq_headers['Accept'] = rf_utility.accept_type['json_xml']
+                        rq_headers['Accept'] = rf_utility.accept_type['xml']
                         response,headers,status = self.http_GET(resource,rq_headers,None)
                         if isinstance(response, dict):
                             # received JSON, skip


### PR DESCRIPTION
…never returned to json

If the service correctly validates the Accept header, the first resource retrieval would have worked fine, but all subsequent retrievals would have tried to use an xml accept header for a json resource