### PR TITLE
Add option to run a single assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ This program has been tested with Python 2.7.10 and 3.4.3.
 
     C:\your_python>  pip --proxy <hostname>:<port> install openpyxl
 3. Copy the 'files included in this test package' into the python.exe installation directory (or put python.exe in your PATH)
-4. Edit properties.json
-	- Set the login and location parameters for your Redfish Service SUTs in the properties.json file.  
-    	- "SUTs[]" collection, You can batch SUTs by adding them to the "SUTs[]" collection to include them in the next run of rf_client.py.  
-	    - DisplayName(required) is a string for your choice of display name for the SUT
-	    - DnsName(required) is the domain name or ip address of the SUT
-	    - LoginName(required) is the Login id for the SUT
-		- Password(required) is the password for the SUT
-		- "AllowAction_LogServiceClearLog": A couple of the assertions verify Actions by sending an Action to Clear the System Log --- if you want to run those (and clear the system log) set "AllowAction_LogServiceClearLog" to "yes" -- "no" (or any other string besides "yes") will disable these Clear Log assertions
+4. Edit `properties.json`
+    - Set the login and location parameters for your Redfish Service System Under Test (SUT) in the `properties.json` file.
+        - `"SUTs"[]` collection: You can batch SUTs by adding them to the `"SUTs"[]` collection to include them in the next run of rf_client.py.
+        - `"DisplayName"` (required) is a string for your choice of display name for the SUT
+        - `"DnsName"` (required) is the domain name or ip address of the SUT
+        - `"LoginName"` (required) is the login name for the SUT
+        - `"Password"` (required) is the password for the SUT
+        - `"AllowAction_LogServiceClearLog"` (optional): A couple of the assertions verify Actions by sending an Action to Clear the System Log --- if you want to run those (and clear the system log) set `"AllowAction_LogServiceClearLog"` to "yes" -- "no" (or any other string besides "yes") will disable these Clear Log assertions
+        - `"SingleAssertion"` (optional): Specify this parameter if you wish to just run a single assertion for this SUT. The parameter value should be the name of one of the test assertion functions, for example `"Assertion_6_1_0"`. If the SingleAssertion parameter is missing or the length of its value is zero, the entire suite of assertions will be run.
 	- Set the parameters for Metadata file download include proxy setting, if applicable or set values to 'none'
 	- Set the parameters for Event Subscription and related Test Event generation. Note that the Event related assertions do not verify that a Test Event actually gets delivered to the "Destination" you specify - but the assertions will create a Subscription and request that the Service issue a Test Event to the Subscription "Destination" using the Test Event parameters you set here
 5. For operational results, open a DOS box and cd to the directory where you placed the files included with this package (example C:\rf_client_dir) and then run rf_client.py. (Make sure openpyxl is installed with this version of python else it will error out.)

--- a/rfs_test/__init__.py
+++ b/rfs_test/__init__.py
@@ -16,8 +16,9 @@
 import logger
 from rfs_test import TEST_protocol_details
 from rfs_test import TEST_datamodel_schema
-from rfs_test_in_progress import TEST_service_details
-from rfs_test_in_progress import TEST_security
+# from rfs_test_in_progress import TEST_service_details
+# from rfs_test_in_progress import TEST_security
+
 
 ###################################################################################################
 # Name: run(sut)
@@ -30,12 +31,44 @@ def run(sut):
     log.init_xl()
     ## Open/initialize the log files
     log.assertion_log('OPEN', None, sut.SUT_prop, sut.Redfish_URIs['Service_Root'])
-    # Run assertions
-    TEST_protocol_details.run(sut, log)
-    TEST_datamodel_schema.run(sut, log)
-    #TEST_service_details.run(sut, log)
-    #TEST_security.run(sut, log)
-    ## end: assertion verification
+    if 'SingleAssertion' in sut.SUT_prop and len(sut.SUT_prop.get('SingleAssertion')) > 0:
+        # Run single assertion
+        run_single([TEST_protocol_details, TEST_datamodel_schema], sut, log)
+    else:
+        # Run all assertions
+        TEST_protocol_details.run(sut, log)
+        TEST_datamodel_schema.run(sut, log)
+        #TEST_service_details.run(sut, log)
+        #TEST_security.run(sut, log)
+        ## end: assertion verification
     ## close log files
     #-log.assertion_log('CLOSE', None)
 # end run
+
+
+###################################################################################################
+# Name: run_single(modules, sut, log)
+# Run a single assertion. The 'SingleAssertion' property in the SUT config specifies the name of
+# the assertion function to run.
+# modules == the list of modules to search for the named assertion
+# sut == the instance of SUT type obj (rf_sut.py) for which the assertion is being run
+# log ==  the log instance to use for logging results
+###################################################################################################
+def run_single(modules, sut, log):
+    if 'SingleAssertion' in sut.SUT_prop and len(sut.SUT_prop.get('SingleAssertion')) > 0:
+        assertion = sut.SUT_prop.get('SingleAssertion')
+    else:
+        print('ERROR: run_single() called to run single assertion, but no "SingleAssertion" property found in SUT')
+        return
+    func = None
+    for mod in modules:
+        if hasattr(mod, assertion) and callable(getattr(mod, assertion)):
+            func = getattr(mod, assertion)
+            break
+    if func is not None:
+        print('Running single assertion "{}"'.format(assertion))
+        func(sut, log)
+    else:
+        print('ERROR: "SingleAssertion" property was specified in config, but function named "{}" was not found'
+              .format(assertion))
+# end run_single


### PR DESCRIPTION
To make development and test of a particular assertion more efficient, added an option to run a single assertion instead of the entire suite of assertions.

Snippet of a config that uses this new option (note new **"SingleAssertion"** entry):

```
"RedfishServiceCheckTool_SUTConfiguration": {
    "SUTs": [
      {
        "Password": "********",
        "LoginName": "admin",
        "AllowAction_LogServiceClearLog": "yes",
        "DnsName": "127.0.0.1",
        "DisplayName": "my-test-server",
        "RedfishVersion": "v1",
        "SingleAssertion": "Assertion_6_5_18"
      }
    ],
```