### PR TITLE
Minor fixes to get tool working with Python 2

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -440,7 +440,7 @@ class Log:
             # log pass/fail status to the text log 
             if (log_control != self.PASS or log_control != self.INCOMPLETE):
                 # include the assertion description in the text log
-                log_string =  ('Assertion Description: %s\n<--- Assertion %s: %s\n' % (assertion_description, self.AssertionID, log_control))
+                log_string =  ('Assertion Description: %s\n<--- Assertion %s: %s\n' % (assertion_description.encode('utf-8'), self.AssertionID, log_control))
             else:
                 log_string =  ('<--- Assertion %s: %s\n' % (self.AssertionID, log_control))
 

--- a/rfs_test/TEST_datamodel_schema.py
+++ b/rfs_test/TEST_datamodel_schema.py
@@ -23,6 +23,7 @@ import sys
 import re
 import rf_utility
 import xml.etree.ElementTree as ET
+from xml.dom import minidom
 
 # map python 2 vs 3 imports
 if (sys.version_info < (3, 0)):
@@ -33,6 +34,7 @@ if (sys.version_info < (3, 0)):
     from httplib import HTTPSConnection, HTTPConnection, HTTPResponse
     import urllib
     import urllib2
+    from urllib import urlopen
 else:
     # Python 3
     Python3 = True
@@ -41,7 +43,6 @@ else:
     from http.client import HTTPSConnection, HTTPConnection, HTTPResponse
     from urllib.request import urlopen
     import urllib
-    from xml.dom import minidom
 
 import ssl
 import re

--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -38,6 +38,7 @@ if (sys.version_info < (3, 0)):
     from httplib import HTTPSConnection, HTTPConnection, HTTPResponse
     import urllib
     import urllib2
+    from urllib import urlopen
 else:
     # Python 3
     Python3 = True
@@ -3772,7 +3773,7 @@ def Assertion_6_5_20(self, log):
                             print(schema)
                             uris = "http://redfish.dmtf.org/schemas/v1/"+schema
                             print(uris)
-                            f = urllib.request.urlopen(uris)
+                            f = urlopen(uris)
                             myfile = f.read()
                             count = count + 1
                             #myfile = myfile.decode('utf-8')


### PR DESCRIPTION
Tested with python 2.7.12

logger.py: Some assertions from the xls have unicode characters which Python cannot format using % notation. Re-encoding that string

TEST_datamodel_schema.py: Fixed imports for urlopen and minidom

TEST_protocol_details.py: Fixed import for urlopen