### PR TITLE
Corrected logic when looking for the @odata.nextLink property

### DIFF
--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -4021,16 +4021,14 @@ def Assertion_6_5_23_1(self, log) :
                             for m in member_array:
                                 count = count+1
                     if count<=member_count: 
-                        for key in json_payload:
-                            nextlink = 'Members@odata.nextLink'
-                            if key == nextlink:
-                                if json_payload[key] is None:
-                                    assertion_status = log.FAIL
-                                    log.assertion_log('line','property %s should have a value, found %s' %(nextlink, json_payload[key]))
-
-                            else :
+                        nextlink = 'Members@odata.nextLink'
+                        if nextlink in json_payload:
+                            if json_payload[nextlink] is None:
                                 assertion_status = log.FAIL
-                                log.assertion_log('line', 'property %s should be present in the resource %s' %(nextlink,relative_uri))
+                                log.assertion_log('line','property %s should have a value, found %s' %(nextlink, json_payload[key]))
+                        else:
+                            assertion_status = log.FAIL
+                            log.assertion_log('line', 'property %s should be present in the resource %s' %(nextlink,relative_uri))
 
             else:      
                 assertion_status = log.WARN


### PR DESCRIPTION
Previously, this was looping all keys and checking for equality to the nextlink key. Since all keys were being looped, the comparison would fail on any other key and the assertion would be marked as failed

Now explicitly checking for the key in the dictionary