### PR TITLE
Allow the metadata document to reference self-hosted or swordfish sch…

### DIFF
--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -3766,13 +3766,7 @@ def Assertion_6_5_20(self, log):
                         for d in dataServices:
                             uris = d.getAttribute('Uri')
                             print('The uri is %s' %uris)
-                            #schema = uris.split('Schemas/')
-                            schema = uris.rsplit('/', 1)
-                            schema = schema[1]
-                            print(schema)
-                            uris = "http://redfish.dmtf.org/schemas/v1/"+schema
-                            print(uris)
-                            f = urllib.request.urlopen(uris)
+                            f = urlopen(uris)
                             myfile = f.read()
                             count = count + 1
                             #myfile = myfile.decode('utf-8')


### PR DESCRIPTION
…emas

Previously the schema filename was being extracted from the URL and the redfish schema base URL (http://redfish.dmtf.org/schemas/v1/) was being prepended

This breaks self-hosted or swordfish schema references, and shouldn't be necessary as the references should contain a full URL to the referenced schema