### PR TITLE
Added resource being referenced for assertion failure messages in 6.5.17

### DIFF
--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -3535,10 +3535,12 @@ def Assertion_6_5_17(self, log) :
             key = '@odata.id'
             if key not in json_payload:
                 assertion_status = log.FAIL
-                log.assertion_log('line', "Expected property %s in response body " % (key) )
+                log.assertion_log('line', "Expected property %s in response body for resource %s"
+                                  % (key, relative_uris[relative_uri]))
             elif json_payload[key] is None:
                 assertion_status = log.FAIL
-                log.assertion_log('line', "Expected property %s with a unique identifier in json body " % (key) )
+                log.assertion_log('line', "Property %s missing a unique identifier in response body for resource %s"
+                                  % (key, relative_uris[relative_uri]))
 
     log.assertion_log(assertion_status, None)
     return (assertion_status)


### PR DESCRIPTION
When conformance check fails, include resource being referenced in log message so user can properly diagnose.

Fixes #30 