### PR TITLE
Improve error handling for assertion 6.5.20

### DIFF
--- a/rf_sut.py
+++ b/rf_sut.py
@@ -457,7 +457,7 @@ class SUT():
         # init SchemaModel obj
         csdl_schema_model = SchemaModel()
         rq_headers = self.request_headers()
-        rq_headers['Accept'] = rf_utility.accept_type['xml']
+        rq_headers['Accept'] = rf_utility.accept_type['xml_utf8']
         authorization = 'off'
         #get service's $metadata json_payload 
         xml_payload, headers, status = self.http_GET(metadata_uri, rq_headers, authorization)

--- a/rf_sut.py
+++ b/rf_sut.py
@@ -457,7 +457,7 @@ class SUT():
         # init SchemaModel obj
         csdl_schema_model = SchemaModel()
         rq_headers = self.request_headers()
-        rq_headers['Accept'] = rf_utility.accept_type['xml_utf8']
+        rq_headers['Accept'] = rf_utility.accept_type['xml']
         authorization = 'off'
         #get service's $metadata json_payload 
         xml_payload, headers, status = self.http_GET(metadata_uri, rq_headers, authorization)

--- a/rf_utility.py
+++ b/rf_utility.py
@@ -64,7 +64,7 @@ accept_type = {\
     'xml' : 'application/xml',\
     'bad' : 'snooop/dog' ,\
     'json_utf8' : 'application/json;charset=utf-8' ,\
-    'json_xml' : 'application/xml;charset=utf-8'
+    'xml_utf8' : 'application/xml;charset=utf-8'
 }
 content_type = {\
     'utf8' : 'application/json; charset=utf-8' ,\

--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -738,7 +738,7 @@ def Assertion_6_1_1(self,log) :
     json_payload, headers, status_3 = self.http_GET(self.Redfish_URIs['Service_Odata_Doc'], rq_headers, authorization)
 
     # Update the Accept header in the request since the metadata doc is XML
-    rq_headers['Accept'] = rf_utility.accept_type['xml']
+    rq_headers['Accept'] = rf_utility.accept_type['xml_utf8']
     json_payload, headers, status_4 = self.http_GET(self.Redfish_URIs['Service_Metadata_Doc'], rq_headers, authorization)
     print('The different status are %s, %s, %s, %s' %(status_1, status_2, status_3, status_4))
     if ( status_1 == status_2 == status_3 == status_4 == 200) :
@@ -849,7 +849,7 @@ def Assertion_6_3_1(self, log) :
     if assertion_status == log.PASS:
         log.assertion_log('line',"~ GET %s : HTTP status %s:%s" % (self.Redfish_URIs['Service_Odata_Doc'], status, rf_utility.HTTP_status_string(status)) ) 
 
-    rq_headers ['Accept'] = rf_utility.accept_type['xml']
+    rq_headers ['Accept'] = rf_utility.accept_type['xml_utf8']
     json_payload, headers, status = self.http_GET(self.Redfish_URIs['Service_Metadata_Doc'], rq_headers, authorization)
     assertion_status_ = self.response_status_check(self.Redfish_URIs['Service_Metadata_Doc'], status, log)      
     # manage assertion status
@@ -2044,10 +2044,10 @@ def Assertion_6_4_2_1(self, log) :
     authorization = 'off'
 
     rq_headers = self.request_headers()
-    rq_headers['Accept'] = rf_utility.accept_type['xml']
+    rq_headers['Accept'] = rf_utility.accept_type['xml_utf8']
 
     json_payload, headers, status = self.http_GET(self.Redfish_URIs['Service_Metadata_Doc'], rq_headers, authorization)
-    log.assertion_log('line', "~ GET %s with Accept type '%s'" % (self.Redfish_URIs['Service_Metadata_Doc'], rf_utility.accept_type['xml']))
+    log.assertion_log('line', "~ GET %s with Accept type '%s'" % (self.Redfish_URIs['Service_Metadata_Doc'], rf_utility.accept_type['xml_utf8']))
     assertion_status_ = self.response_status_check(self.Redfish_URIs['Service_Metadata_Doc'], status, log)         
     # manage assertion status
     assertion_status = log.status_fixup(assertion_status,assertion_status_)
@@ -2057,7 +2057,7 @@ def Assertion_6_4_2_1(self, log) :
         # check1: the response header should have the content type xml as requested    
         if rf_utility.accept_type['xml'] not in headers['content-type']:
             assertion_status = log.FAIL
-            log.assertion_log('line', "Service did not support the Accept request for %s for %s" % (rf_utility.accept_type['xml'], self.Redfish_URIs['Service_Metadata_Doc']))
+            log.assertion_log('line', "Service did not support the Accept request for %s for %s" % (rf_utility.accept_type['xml_utf8'], self.Redfish_URIs['Service_Metadata_Doc']))
 
         #check2: the content returned in response body should be xml, validate it by parsing
         elif not json_payload:
@@ -2070,7 +2070,7 @@ def Assertion_6_4_2_1(self, log) :
                 xml = ET.fromstring(json_payload)
                 if xml is None:
                     assertion_status = log.FAIL
-                    log.assertion_log('line', "Service did not support the Accept request for %s for %s" % (rf_utility.accept_type['xml'], self.Redfish_URIs['Service_Metadata_Doc']))
+                    log.assertion_log('line', "Service did not support the Accept request for %s for %s" % (rf_utility.accept_type['xml_utf8'], self.Redfish_URIs['Service_Metadata_Doc']))
             except ET.ParseError as e:
                 assertion_status = log.FAIL
                 log.assertion_log('line', "XML parse error for %s, exception: %s" % (
@@ -3761,7 +3761,7 @@ def Assertion_6_5_20(self, log):
                         resource = json_payload['@odata.context']
                         #r = requests.get(resource)
                         #print('The response is %s' %r)
-                        rq_headers['Accept'] = rf_utility.accept_type['xml']
+                        rq_headers['Accept'] = rf_utility.accept_type['xml_utf8']
                         response,headers,status = self.http_GET(resource,rq_headers,None)
                         if isinstance(response, dict):
                             # received JSON, skip
@@ -4442,7 +4442,7 @@ def Assertion_6_5_8(self, log) :
                 resource = json_payload['@odata.context']
                 #r = requests.get(resource)
                 #print('The response is %s' %r)
-                rq_headers['Accept'] = rf_utility.accept_type['xml']
+                rq_headers['Accept'] = rf_utility.accept_type['xml_utf8']
                 response,headers,status = self.http_GET(resource,rq_headers,None)
                 if status != 200:
                     print('Unexpected status {} returned from resource {}'.format(status, resource))
@@ -4532,7 +4532,7 @@ def Assertion_6_5_9(self, log) :
                 if 'ServiceRoot' in resource :
                         #r = requests.get(resource)
                         #print('The response is %s' %r)
-                        rq_headers['Accept'] = rf_utility.accept_type['xml']
+                        rq_headers['Accept'] = rf_utility.accept_type['xml_utf8']
                         response,headers,status = self.http_GET(resource,rq_headers,None)
                         if status != 200:
                             print('Unexpected status {} returned from resource {}'.format(status, resource))

--- a/schema.py
+++ b/schema.py
@@ -787,7 +787,7 @@ for action in resource_namespace.Actions:
                     self.serialize_edmx(schema_root, schema_file)
 
         elif schema_payload and schema_uri:
-            schema_root = ET.fromstring(schema_payload)
+            schema_root = ET.fromstring(schema_payload.strip(b'\x00'))
             if schema_root is not None:
                 self.serialize_edmx(schema_root, schema_uri)
 


### PR DESCRIPTION
Changes include:
- In assertion 6.5.20 added status checking and exception handling
- In assertion 6.5.20 added code to handle fetching XML schemas via relative URIs as well as full URLs
- Removed checks for JSON response payloads when fetching XML schema; the correct fix was to check the status code from the GET
- Strip potential trailing NUL byte at end of XML payloads before parsing

Fixes #21 