### PR TITLE
Harden error response checking in Assertion_6_5_40

### DIFF
--- a/rf_sut.py
+++ b/rf_sut.py
@@ -433,7 +433,7 @@ class SUT():
             if '@odata.context' in json_payload:
                 odata_context = json_payload['@odata.context']
             else:
-                print('Warning: OData Service Spec object does not comply with the Specification. @odata.context expected but not found in %s json_payload' % (service_odata_uri))
+                print('Warning: OData Service Spec object does not conform to the Specification. @odata.context expected but not found in %s json_payload' % (service_odata_uri))
 
             try:
                 #following dictionary keys are traced out by Redfish specification
@@ -441,7 +441,7 @@ class SUT():
                     for resource in json_payload['value']:
                         values[resource['name']] = {'kind' : resource['kind'], 'url' : resource['url']} 
             except:
-                print('Warning: OData Service Spec object does not comply with the Specification')
+                print('Warning: OData Service Spec object does not conform to the Specification')
                 return None, None
                 
         return odata_context, values

--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -4829,7 +4829,7 @@ def Assertion_6_5_40_old(self, log) :
 
 ###################################################################################################
 # Name: Assertion_6_5_40(self, log)                                               
-# Description: This section includes the testinng for all the 'Message Object' 
+# Description: This section includes the testing for all the 'Message Object'
 # Test performed by Priyanka
 ###################################################################################################
 
@@ -4844,43 +4844,41 @@ def Assertion_6_5_40(self, log) :
     relative_uris = self.relative_uris
     rq_headers = self.request_headers()
     for relative_uri in relative_uris:
-        json_payload, headers, status = self.http_GET(relative_uris[relative_uri], rq_headers, authorization)
-        if self.allowable_method('PATCH', headers):
-            rq_body = {'Name': 'New Name'}
-            json_payload, headers, status = self.http_PATCH(relative_uris[relative_uri], rq_headers,
-                                                            rq_body, authorization)
-            if status >= 400 and isinstance(json_payload, dict) and 'error' in json_payload:
-                message_error = json_payload['error']
-                message_object = message_error['@Message.ExtendedInfo']
-                message_object = message_object[0]
-                print('Message object is %s' % message_object)
-                if 'MessageId' in message_object:
-                    found_message_id = True
-                    name = message_object['MessageId']
-                    if '_' in name:
-                        separator = '_'
-                    elif '.' in name:
-                        separator = '.'
-                    name_ = name.rsplit(separator, 1)
-                    message_key = name_[1]
-                    name_= name_[0]
-                    r_name = name_.rsplit(separator, -1)
-                    registry_name = r_name[0]
-                    major_version = r_name[1]
-                    minor_version = r_name[2]
-                    print('The RegistryName is %s and MajorVersion, MinorVersion is %s, %s and MessageKey is %s' %
-                          (registry_name, major_version, minor_version, message_key))
-                    is_camel_reg = camel(registry_name)
-                    if not is_camel_reg:
-                        log.assertion_log('line', 'RegistryName {} is not Pascal-cased'.format(registry_name))
-                    is_camel_key = camel(message_key)
-                    if not is_camel_key:
-                        log.assertion_log('line', 'MessageKey {} is not Pascal-cased'.format(message_key))
-                    if is_camel_reg and is_camel_key:
-                        assertion_status_ = log.PASS
-                    else:
-                        assertion_status_ = log.FAIL
-                    assertion_status = log.status_fixup(assertion_status, assertion_status_)
+        rq_body = {'Name': 'New Name'}
+        json_payload, headers, status = self.http_PATCH(relative_uris[relative_uri], rq_headers,
+                                                        rq_body, authorization)
+        if status >= 400 and isinstance(json_payload, dict) and 'error' in json_payload:
+            message_error = json_payload['error']
+            message_object = message_error['@Message.ExtendedInfo']
+            message_object = message_object[0]
+            print('Message object is %s' % message_object)
+            if 'MessageId' in message_object:
+                found_message_id = True
+                name = message_object['MessageId']
+                if '_' in name:
+                    separator = '_'
+                elif '.' in name:
+                    separator = '.'
+                name_ = name.rsplit(separator, 1)
+                message_key = name_[1]
+                name_= name_[0]
+                r_name = name_.rsplit(separator, -1)
+                registry_name = r_name[0]
+                major_version = r_name[1]
+                minor_version = r_name[2]
+                print('The RegistryName is %s and MajorVersion, MinorVersion is %s, %s and MessageKey is %s' %
+                      (registry_name, major_version, minor_version, message_key))
+                is_camel_reg = camel(registry_name)
+                if not is_camel_reg:
+                    log.assertion_log('line', 'RegistryName {} is not Pascal-cased'.format(registry_name))
+                is_camel_key = camel(message_key)
+                if not is_camel_key:
+                    log.assertion_log('line', 'MessageKey {} is not Pascal-cased'.format(message_key))
+                if is_camel_reg and is_camel_key:
+                    assertion_status_ = log.PASS
+                else:
+                    assertion_status_ = log.FAIL
+                assertion_status = log.status_fixup(assertion_status, assertion_status_)
 
     if not found_message_id:
         assertion_status_ = log.WARN


### PR DESCRIPTION
In Assertion_6_5_40(), made these fixes:
- hardened the checking of the error response
- fixed the logic/handling of the overall assertion_status return value (PASS/WARN/FAIL)

Also made a minor correction to a couple of messages in rf_sut.py (changed "comply" to "conform").

Fixes #68 