### PR TITLE
6.1.8.1.2: added type checking to avoid unexpected runtime exception

### DIFF
--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -298,6 +298,13 @@ def verifyCreatedObject(object_payload, check_payload, log):
     ]
 
     assertion_status = log.PASS
+
+    if not isinstance(object_payload, dict):
+        assertion_status = log.FAIL
+        log.assertion_log('line', '~ The response body (type {}) returned from POST is not a JSON object, so cannot check it against the GET response'
+                          .format(type(object_payload)))
+        return assertion_status
+
     # check for mismatch...
     for key in check_payload.keys():
         if key in exclude_keys:


### PR DESCRIPTION
For Assertion_6_1_8_1_2(), added type checking of the response body from the POST request to avoid unexpected runtime exception if the body isn't JSON.

Fixes #108 