### PR TITLE
Disable out-of-scope datamodel schema tests

### DIFF
--- a/rfs_test/__init__.py
+++ b/rfs_test/__init__.py
@@ -46,9 +46,13 @@ def run(sut):
     else:
         # Run all assertions
         TEST_protocol_details.run(sut, log)
-        #TEST_security.run(sut, log)
-        #TEST_service_details.run(sut, log)
-        TEST_datamodel_schema.run(sut, log)
+
+        # These assertions are incomplete or WIP
+        # TEST_security.run(sut, log)
+        # TEST_service_details.run(sut, log)
+
+        # These assertions are covered by other tools
+        # TEST_datamodel_schema.run(sut, log)
 
         TEST_manager_account.run(sut, log)
         TEST_computersystem_schema.run(sut, log)


### PR DESCRIPTION
Per discussion in the Tools TF call, disabled the entire TEST_datamodel_schema.py module.
These assertions (7.*) just validate the CSDL schema files or validate that the service payloads adhere to the schemas. These tests are already covered by the Redfish-Service-Validator, tools in https://github.com/DMTF/Redfish-Tools, and Travis CI tests in https://github.com/DMTF/Redfish.

Fixes #181 