### PR TITLE
Fix KeyError in Assertion_6_5_14

### DIFF
--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -3398,12 +3398,10 @@ def verify_singleton_urlcxt_new(json_payload, assertion_status, self, log):
                         #still need to implement. get the annotation term-Required on create and save the name and typr in the dictionary
                         for annotations in property.Annotations :
                             if annotations.Term == 'Redfish.Required' :
-                                if property.Name not in json_payload[property.Name] :
+                                if property.Name not in json_payload:
                                     assertion_status= log.FAIL
-                                elif isinstance(json_payload[property.Name],dict) :
-                                    assertion_status= log.FAIL
-                                    log.assertion_log('line', "The property %s is a complex type" % property.Name)
-
+                                    log.assertion_log('line', "Required property %s is missing from resource %s" % (
+                                        property.Name, json_payload.get('@odata.id', '')))
     return assertion_status
 
 ###################################################################################################


### PR DESCRIPTION
I fixed the KeyError seen in issue #186.

But note the following oddities here:
1. Testing for required properties in the JSON response payloads is handled by the Redfish-Service-Validator. The Redfish-Service-Conformance-Check tool should not even be doing this type of check (should be resolved when issue #177 is fixed).
2. Assertion_6_5_14 is supposed to be checking the format of the "@odata.context" value but is instead checking for missing required properties.

Fixes #186 
