### PR TITLE
Remove "Server" as required response header; fix deprecated openpyxl call

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -228,7 +228,7 @@ class Log:
             return 0
 
         # get a 'handle to the assertions sheet
-        self.XlAssertionSheet = self.XlAssertionWb.get_active_sheet()
+        self.XlAssertionSheet = self.XlAssertionWb.active
 
         return 1
     #

--- a/rfs_test/TEST_protocol_details.py
+++ b/rfs_test/TEST_protocol_details.py
@@ -2424,7 +2424,7 @@ def Assertion_6_5_1(self, log) :
 #   header is not foundAdvisory WARN if any header not in the response header table in spec is found
 ###################################################################################################
 def response_header_check(headers, url, log):
-    required_headers = ['odata-version', 'content-type', 'server', 'link', 'cache-control']
+    required_headers = ['odata-version', 'content-type', 'link', 'cache-control']
     conditional_headers = ['etag', 'location']
     additional_headers = ['content-encoding', 'content-length', 'via', 'max-forwards', 'retry-after']
     # what we think is required in context


### PR DESCRIPTION
The `Server` response header is no longer required as of the 1.9.0 spec. Removed it from the list of required headers being checked.

Also, while testing this in a newly installed Python environment I encountered an unrelated problem that `Workbook.get_active_sheet()` was no longer present in the latest version of `openpyxl`. Apparently that method was deprecated about 5 years ago (in version 2.3) and has been removed from the latest versions (3.0.n). So I went ahead and updated the code in this PR to use the supported `Workbook.active` property.

Fixes #188 