### PR TITLE
Deprecate in favor of the new Redfish-Protocol-Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@ Copyright 2016-2019 DMTF. All rights reserved.
 
 # Redfish Service Conformance Check Tool
 
+## Deprecated
+
+This tool has been deprecated in favor of a newer, more comprehensive protocol validation tool. Please use the new [Redfish-Protocol-Validator](https://github.com/DMTF/Redfish-Protocol-Validator) tool instead.
+
+## Description
+
 This tool checks an operational Redfish Service to see that it conforms to the normative statements from the Redfish specification (see assertions in redfish-assertions.xlxs). Assertion coverage is growing (development in process) and future revisions of the tool will increase coverage of the Assertions. To see which Assertions are covered by a revision - run the tool and look at the markup to the SUTs copy of the xlxs file after the check is run. The assertion numbers shown in the reports are based on the Redfish specification version 1.0.5.
 
 This program has been tested with Python 2.7.10 and 3.4.3.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright 2016-2019 DMTF. All rights reserved.
 
 ## Deprecated
 
-This tool has been deprecated in favor of a newer, more comprehensive protocol validation tool. Please use the new [Redfish-Protocol-Validator](https://github.com/DMTF/Redfish-Protocol-Validator) tool instead.
+This tool is deprecated in favor of a newer, faster, and more comprehensive protocol validation tool. Please use the new [Redfish-Protocol-Validator](https://github.com/DMTF/Redfish-Protocol-Validator) tool instead.
 
 ## Description
 


### PR DESCRIPTION
Add a note at the top of the README.md file to mark this tool as deprecated and point to the new Redfish-Protocol-Validator tool.